### PR TITLE
Add startupTime parameter to UdpEchoApp

### DIFF
--- a/src/inet/applications/udpapp/UdpEchoApp.h
+++ b/src/inet/applications/udpapp/UdpEchoApp.h
@@ -21,6 +21,7 @@ class INET_API UdpEchoApp : public ApplicationBase, public UdpSocket::ICallback
   protected:
     UdpSocket socket;
     int numEchoed; // just for WATCH
+    simtime_t startupTime; // Added member variable to store the startupTime parameter value
 
   protected:
     virtual int numInitStages() const override { return NUM_INIT_STAGES; }
@@ -36,9 +37,9 @@ class INET_API UdpEchoApp : public ApplicationBase, public UdpSocket::ICallback
     virtual void socketDataArrived(UdpSocket *socket, Packet *packet) override;
     virtual void socketErrorArrived(UdpSocket *socket, Indication *indication) override;
     virtual void socketClosed(UdpSocket *socket) override;
+    virtual void bindSocket(); // Declared the socket binding method
 };
 
 } // namespace inet
 
 #endif
-

--- a/src/inet/applications/udpapp/UdpEchoApp.ned
+++ b/src/inet/applications/udpapp/UdpEchoApp.ned
@@ -19,6 +19,7 @@ simple UdpEchoApp like IApp
     parameters:
         string interfaceTableModule;   // The path to the InterfaceTable module
         int localPort;  // Local port to listen on
+        double startupTime @unit(s) = default(0s); // Time when the application should start
         @display("i=block/app");
         @lifecycleSupport;
         double stopOperationExtraTime @unit(s) = default(-1s);    // Extra time after lifecycle stop operation finished
@@ -29,4 +30,3 @@ simple UdpEchoApp like IApp
         input socketIn @labels(UdpControlInfo/up);
         output socketOut @labels(UdpControlInfo/down);
 }
-


### PR DESCRIPTION
Adds a `startupTime` parameter to the `UdpEchoApp` module, enabling the application to bind to the socket at a specified startup time.

- Introduces a `startupTime` parameter in `UdpEchoApp.ned` with a default value of `0s`, allowing the application's start time to be configurable.
- Implements scheduling a self-message at `startupTime` in `handleStartOperation()` within `UdpEchoApp.cc`, which defers socket binding until the specified time.
- Adds a new method `bindSocket()` in `UdpEchoApp.cc` and its declaration in `UdpEchoApp.h` to encapsulate the socket binding logic, which is called upon receiving the self-message.
- Modifies `handleMessageWhenUp()` to handle the self-message for socket binding, ensuring the application binds to the socket at the correct time.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/torokati44/inet?shareId=644eb9f1-520f-449b-b988-38103d986e83).